### PR TITLE
Fix codec bug and deprecated use of numpy int and float types.

### DIFF
--- a/qspaceweight.py
+++ b/qspaceweight.py
@@ -70,19 +70,19 @@ parser.add_argument('bvalues', nargs='+',
 
 args = parser.parse_args()
 
-bvalues=np.array(args.bvalues,dtype=np.int)
+bvalues=np.array(args.bvalues,dtype=np.int32)
 n_b0 = int(args.n_b0)
 
 schema = []
 output = []
 
-with open(args.unitary_schema) as csvfile:
+with open(args.unitary_schema, encoding='utf-8') as csvfile:
     reader = csv.reader(csvfile, delimiter='\t', quotechar='|')
     start = False
     for row in reader:
         try:
             if start:
-                u = np.array(row, dtype=np.float)
+                u = np.array(row, dtype=np.float32)
                 schema.append(u)
 
             if row[0] == "#shell":


### PR DESCRIPTION
I received errors running the code as is. One was a codec warning where UTF-8 was not explicitly stated and the other was deprecated use of numpy int types, specifying the precision overcame this. 